### PR TITLE
Added constant.other.proto to symbol list

### DIFF
--- a/Symbol List.YAML-tmPreferences
+++ b/Symbol List.YAML-tmPreferences
@@ -1,7 +1,7 @@
 # [PackageDev] target_format: plist, ext: tmPreferences
 
 name: Symbol List
-scope: "entity.name.class.message.proto, entity.name.class.enum.proto"
+scope: "entity.name.class.message.proto, entity.name.class.enum.proto, constant.other.proto"
 uuid: c2234a3a-2e4e-4c92-af3e-5640847d91c6
 
 

--- a/Symbol List.tmPreferences
+++ b/Symbol List.tmPreferences
@@ -5,7 +5,7 @@
 	<key>name</key>
 	<string>Symbol List</string>
 	<key>scope</key>
-	<string>entity.name.class.message.proto, entity.name.class.enum.proto</string>
+	<string>entity.name.class.message.proto, entity.name.class.enum.proto, constant.other.proto</string>
 	<key>settings</key>
 	<dict>
 		<key>showInIndexedSymbolList</key>


### PR DESCRIPTION
This is mainly so you can quick find an enum value definition through the symbol list and use jump to definition for enum values.
