### PR TITLE
Treat enum names same as message names

### DIFF
--- a/Protobuf.YAML-tmLanguage
+++ b/Protobuf.YAML-tmLanguage
@@ -46,7 +46,7 @@ repository:
     begin: (enum)(\s+)([A-Za-z][A-Za-z0-9_]*)(\s*)(\{)?
     beginCaptures:
       '1': {name: keyword.source.proto}
-      '3': {name: entity.name.class.proto}
+      '3': {name: entity.name.class.message.proto}
     end: \}
     patterns:
     - include: '#option'

--- a/Protobuf.tmLanguage
+++ b/Protobuf.tmLanguage
@@ -102,7 +102,7 @@
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.class.proto</string>
+					<string>entity.name.class.message.proto</string>
 				</dict>
 			</dict>
 			<key>end</key>


### PR DESCRIPTION
This will allow goto_definition command to work to enum as well as to messages.

Otherwise enum names in messages and enum names in enum definitions are treated as similar entity.name.class.proto which is unhelpful for navigation.